### PR TITLE
Add ability to provide a custom array of colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,10 @@ COGs with a single band can be interpreted DEMs.
 
 COGs with a single band can be also converted to images applying a color ramp.
 
-* Use a `raster` source with the url prepended with `cog://` and appended with `#color:` and the color ramp specification.
+* Use a `raster` source with the url prepended with `cog://` and appended with `#color:` and the color ramp specification or an array of custom hex codes.
 * Use a `raster` layer.
+
+#### ColorBrewer or CARTOColors
 
 ```javascript
   map.addSource('sourceId', {
@@ -156,13 +158,29 @@ COGs with a single band can be also converted to images applying a color ramp.
   });
 ```
 
+#### Custom Colors
+
+```javascript
+  map.addSource('sourceId', {
+    type: 'raster',
+    url: 'cog://https://labs.geomatico.es/maplibre-cog-protocol/data/kriging.tif#color:["#ffeda0","#feb24c","#f03b20"],1.7,1.8,c',
+  });
+
+  map.addLayer({
+    id: 'imageId',
+    source: 'sourceId',
+    type: 'raster'
+  });
+```
+
 The color ramp specification consists of the following comma-separated values:
 
 ```
-#color:<colorScheme>,<min>,<max>,<options>
+#color:<colorScheme/customColors>,<min>,<max>,<options>
 ```
 
 * `colorScheme`: Any of the [Color Brewer](https://colorbrewer2.org/) or [CARTOColors](https://carto.com/carto-colors/) schemes are available. See [the Color Ramp cheatsheet](https://labs.geomatico.es/maplibre-cog-protocol/colors.html).
+* `customColors`: An array of hex codes for your color ramp.
 * `min`: A number indicating the minimal value where the color ramp applies.
 * `max`: A number indicating the maximal value where the color ramp applies.
 * `options` (optional):

--- a/examples/custom-color.html
+++ b/examples/custom-color.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Maplibre COG Protocol Example</title>
+  <link rel="stylesheet" href="https://unpkg.com/maplibre-gl/dist/maplibre-gl.css">
+  <script src="https://unpkg.com/maplibre-gl/dist/maplibre-gl.js"></script>
+  <script src="dist/index.js"></script>
+  <style>
+      html, body, #map {
+          margin: 0;
+          width: 100%;
+          height: 100%;
+      }
+
+      #info {
+          display: none;
+          position: absolute;
+          top: 0;
+          left: 0;
+          background: #2d2d2d;
+          border: 1px solid #bbbbbb;
+          color: #bbbbbb;
+          padding: 6px;
+          border-radius: 5px;
+          font-family: monospace;
+          font-size: 18px;
+      }
+  </style>
+</head>
+<body>
+<div id="map"></div>
+<div id="info"></div>
+<script>
+  let map = new maplibregl.Map({
+    container: 'map',
+    style: 'https://geoserveis.icgc.cat/contextmaps/icgc_orto_estandard.json',
+    center: [0.501427, 41.656126],
+    zoom: 16,
+    hash: true
+  });
+
+  maplibregl.addProtocol('cog', MaplibreCOGProtocol.cogProtocol);
+
+  map.on('load', () => {
+    map.addSource('imageSource', {
+      type: 'raster',
+      url: 'cog://./data/kriging.tif#color:["#ff0000", "#00ff00", "#0000ff"],1.7084054885838,1.7919403772937,c',
+      tileSize: 256
+    });
+
+    map.addLayer({
+      source: 'imageSource',
+      id: 'imageLayer',
+      type: 'raster'
+    });
+  });
+
+  map.on('drag', () => document.getElementById('info').style.display = 'none');
+
+  map.on('mousemove', (e) => {
+    const {lngLat: {lat: latitude, lng: longitude}, point: {x, y}} = e;
+    const zoom = map.getZoom();
+
+    document.getElementById('info').style.left = x + 10 + 'px';
+    document.getElementById('info').style.top = y + 20 + 'px';
+
+    MaplibreCOGProtocol.locationValues('./data/kriging.tif', {latitude, longitude}, zoom)
+      .then(result => {
+        const value = Math.round(result[0] * 1000) / 1000;
+        if (isNaN(value)) {
+          map.getCanvas().style.cursor = '';
+          document.getElementById('info').style.display = 'none';
+        } else {
+          map.getCanvas().style.cursor = 'default';
+          document.getElementById('info').style.display = 'block';
+          document.getElementById('info').innerHTML = `Value: <b>${value}</b>`;
+        }
+      });
+  });
+
+</script>
+</body>
+</html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -11,6 +11,7 @@
 <ul>
   <li><a href="photo.html" target="_blank">RGB Image example</a></li>
   <li><a href="color.html" target="_blank">Color Ramp example</a></li>
+  <li><a href="custom-color.html" target="_blank">Custom Color Ramp example</a></li>
   <li><a href="dem.html" target="_blank">Huge Digital Elevation Model</a> (11 GB file covering Catalonia at 2 m/pix)</li>
   <li><a href="https://labs.geomatico.es/maplibre-cog-protocol-examples/" target="_blank">Advanced Viewer</a></li></li>
 </ul>

--- a/src/render/colorScale.ts
+++ b/src/render/colorScale.ts
@@ -345,10 +345,10 @@ const colorScale = ({ colorScheme, customColors, min, max, isReverse = false, is
     } else {
       throw new Error(`"${colorScheme}" is not a supported color scheme`);
     }
-  } else if (customColors.length >= 3) {
+  } else if (customColors.length >= 2) {
     colors = customColors;
   } else {
-    throw new Error(`You must provide at least 3 colors`);
+    throw new Error(`You must provide at least 2 colors`);
   }
 
   const colorInts = colors.map(hexToIntColor);

--- a/src/render/colorScale.ts
+++ b/src/render/colorScale.ts
@@ -1,6 +1,6 @@
-import {scaleThreshold, scaleLinear} from 'd3-scale';
+import { scaleLinear, scaleThreshold } from 'd3-scale';
 
-type HEXColor = `#${string}`;
+export type HEXColor = `#${string}`;
 
 export const COLOR_SCHEMES = {
   BrewerYlGn3: ['#f7fcb9', '#addd8e', '#31a354'],
@@ -328,6 +328,7 @@ const thresholds = (min: number, max: number, n: number): Array<number> =>
   );
 
 export type ColorScaleParams = {
+  customColors: Array<HEXColor>,
   colorScheme: string,
   min: number,
   max: number,
@@ -335,21 +336,33 @@ export type ColorScaleParams = {
   isContinuous?: boolean
 }
 
-const colorScale = ({colorScheme, min, max, isReverse = false, isContinuous = false}: ColorScaleParams) => {
-  if (isValidColorSchemeName(colorScheme)) {
-    const colors = COLOR_SCHEMES[colorScheme].map(hexToIntColor);
-    const range = isReverse ? colors.reverse() : colors;
+const colorScale = ({ colorScheme, customColors, min, max, isReverse = false, isContinuous = false }: ColorScaleParams) => {
+  let colors: Array<HEXColor>;
 
-    if (isContinuous) {
-      const domain = intervals(min, max, range.length);
-      return scaleLinear(domain, range).clamp(true);
+  if (colorScheme) {
+    if (isValidColorSchemeName(colorScheme)) {
+      colors = COLOR_SCHEMES[colorScheme];
     } else {
-      const domain = thresholds(min, max, range.length);
-      return scaleThreshold(domain, range);
+      throw new Error(`"${colorScheme}" is not a supported color scheme`);
     }
+  } else if (customColors.length >= 3) {
+    colors = customColors;
   } else {
-    throw new Error(`"${colorScheme}" is not a supported color scheme`);
+    throw new Error(`You must provide at least 3 colors`);
+  }
+
+  const colorInts = colors.map(hexToIntColor);
+
+  const range = isReverse ? colorInts.reverse() : colorInts;
+
+  if (isContinuous) {
+    const domain = intervals(min, max, range.length);
+    return scaleLinear(domain, range).clamp(true);
+  } else {
+    const domain = thresholds(min, max, range.length);
+    return scaleThreshold(domain, range);
   }
 }
 
-export {colorScale, colorSchemeNames};
+export { colorScale, colorSchemeNames };
+

--- a/test/cogProtocol.spec.ts
+++ b/test/cogProtocol.spec.ts
@@ -1,11 +1,11 @@
-import {test, expect, jest} from '@jest/globals';
+import { expect, jest, test } from '@jest/globals';
 
-import {CogMetadata, TileJSON, TypedArray} from '../src/types';
 import cogProtocol from '../src/cogProtocol';
 import CogReader from '../src/read/CogReader';
 import renderColor from '../src/render/renderColor';
 import renderPhoto from '../src/render/renderPhoto';
 import renderTerrain from '../src/render/renderTerrain';
+import { CogMetadata, TileJSON, TypedArray } from '../src/types';
 
 
 // Test data
@@ -129,6 +129,30 @@ describe('cogProtocol', () => {
 
     const expectedColorScale = {
       colorScheme: 'scheme',
+      customColors: [],
+      min: 10,
+      max: 20,
+      isReverse: true,
+      isContinuous: true
+    }
+
+    expect(mockedCogReader).toHaveBeenCalledWith('file.tif');
+    expect(mockedRenderColor).toHaveBeenCalledWith(fakeRawTile, {...fakeMetadata, colorScale: expectedColorScale});
+
+    const data: Uint8ClampedArray = response.data as unknown as Uint8ClampedArray;
+    expect(isEqualArray(data, fakeImageTile)).toBe(true);
+  });
+
+  test('image requests with #color:{customColors},{min},{max},{modifiers} in url should parse its parameters and return a TerrainRGB image', async () => {
+
+    const response = await cogProtocol({
+      type: 'image',
+      url: 'cog://file.tif#color:["#f7fcb9", "#addd8e", "#31a354"],10,20,-c/1/2/3'
+    });
+
+    const expectedColorScale = {
+      colorScheme: '',
+      customColors: ['#f7fcb9', '#addd8e', '#31a354'],
       min: 10,
       max: 20,
       isReverse: true,

--- a/test/render/colorScale.spec.ts
+++ b/test/render/colorScale.spec.ts
@@ -22,14 +22,14 @@ describe('colorScale', () => {
     ).toThrow('"notValid" is not a supported color scheme');
   });
 
-  test('throws an error if less than 3 custom colors are provided', () => {
+  test('throws an error if less than 2 custom colors are provided', () => {
     const colorScheme = "";
-    const customColors: Array<HEXColor> = ['#f7fcb9', '#addd8e'];
+    const customColors: Array<HEXColor> = ['#f7fcb9'];
     const min = 0, max = 1;
 
     expect(() =>
       colorScale({colorScheme, customColors, min, max})
-    ).toThrow('You must provide at least 3 colors');
+    ).toThrow('You must provide at least 2 colors');
   });
 
   test('can generate a discrete color interpolator', () => {

--- a/test/render/colorScale.spec.ts
+++ b/test/render/colorScale.spec.ts
@@ -1,6 +1,6 @@
-import {test, expect, describe} from '@jest/globals';
+import { describe, expect, test } from '@jest/globals';
 
-import {colorScale, colorSchemeNames} from '../../src/render/colorScale';
+import { colorScale, colorSchemeNames, HEXColor } from '../../src/render/colorScale';
 
 describe('colorSchemeNames', () => {
   test('is an array containing supported color scale names', () => {
@@ -18,9 +18,19 @@ describe('colorScale', () => {
     const min = 0, max = 1;
 
     expect(() =>
-      colorScale({colorScheme, min, max})
+      colorScale({colorScheme, customColors: [], min, max})
     ).toThrow('"notValid" is not a supported color scheme');
-  })
+  });
+
+  test('throws an error if less than 3 custom colors are provided', () => {
+    const colorScheme = "";
+    const customColors: Array<HEXColor> = ['#f7fcb9', '#addd8e'];
+    const min = 0, max = 1;
+
+    expect(() =>
+      colorScale({colorScheme, customColors, min, max})
+    ).toThrow('You must provide at least 3 colors');
+  });
 
   test('can generate a discrete color interpolator', () => {
     const colorScheme = 'BrewerYlGn3';
@@ -32,7 +42,7 @@ describe('colorScale', () => {
     const color3 = [49, 163, 84];
 
     // Returns a function
-    const color = colorScale({colorScheme, min, max});
+    const color = colorScale({colorScheme, customColors: [], min, max});
     expect(typeof color).toBe('function');
 
     // Min and max values resolve to first and last colors in the scale
@@ -59,7 +69,7 @@ describe('colorScale', () => {
     const color3 = [49, 163, 84];
 
     // Returns a function
-    const color = colorScale({colorScheme, min, max, isReverse: true});
+    const color = colorScale({colorScheme, customColors: [], min, max, isReverse: true});
     expect(typeof color).toBe('function');
 
     // Min and max values resolve to last and first colors in the scale
@@ -86,7 +96,7 @@ describe('colorScale', () => {
     const color3 = [49, 163, 84];
 
     // Returns a function
-    const color = colorScale({colorScheme, min, max, isContinuous: true});
+    const color = colorScale({colorScheme, customColors: [], min, max, isContinuous: true});
     expect(typeof color).toBe('function');
 
     // Min, max and mid values resolve to exact colors in the scale
@@ -113,7 +123,7 @@ describe('colorScale', () => {
     const color3 = [49, 163, 84];
 
     // Returns a function
-    const color = colorScale({colorScheme, min, max, isContinuous: true, isReverse: true});
+    const color = colorScale({colorScheme, customColors: [], min, max, isContinuous: true, isReverse: true});
     expect(typeof color).toBe('function');
 
     // Min, max and mid values resolve to exact colors in the scale


### PR DESCRIPTION
We'd love to use this library but be able to provide our own colors, so I've created this PR to enable providing either the existing ColorBrewer or CARTOColors scheme or an array of hex codes to the `color` hash.

e.g.

```typescript
map.addSource('sourceId', {
    type: 'raster',
    url: 'cog://https://labs.geomatico.es/maplibre-cog-protocol/data/kriging.tif#color:["#ffeda0","#feb24c","#f03b20"],1.7,1.8,c',
  });
```