### PR TITLE
Add ability to provide custom request headers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,6 @@ import cogProtocol from './cogProtocol';
 import {colorScale, colorSchemeNames} from './render/colorScale';
 import setColorFunction from './render/custom/setColorFunction';
 import locationValues from './read/locationValues';
-import {getCogMetadata} from './read/CogReader';
+import {getCogMetadata, setRequestHeaders} from './read/CogReader';
 
-export {cogProtocol, colorScale, colorSchemeNames, setColorFunction, locationValues, getCogMetadata};
+export {cogProtocol, colorScale, colorSchemeNames, setColorFunction, locationValues, getCogMetadata, setRequestHeaders};

--- a/src/read/CogReader.ts
+++ b/src/read/CogReader.ts
@@ -11,6 +11,7 @@ import {
 const ONE_HOUR_IN_MILLISECONDS = 60 * 60 * 1000;
 
 let pool: Pool;
+let requestHeaders: Record<string, string> | undefined;
 
 const geoTiffCache = new QuickLRU<string, Promise<GeoTIFF>>({maxSize: 16, maxAge: ONE_HOUR_IN_MILLISECONDS});
 const metadataCache = new QuickLRU<string, Promise<CogMetadata>>({maxSize: 16, maxAge: ONE_HOUR_IN_MILLISECONDS});
@@ -26,7 +27,7 @@ const CogReader = (url: string) => {
     if (cachedGeoTiff) {
       return cachedGeoTiff;
     } else {
-      const geoTiff = fromUrl(url);
+      const geoTiff = fromUrl(url, {headers: requestHeaders});
       geoTiffCache.set(url, geoTiff);
       return geoTiff;
     }
@@ -121,5 +122,9 @@ const CogReader = (url: string) => {
 };
 
 export const getCogMetadata = (url: string) => CogReader(url).getMetadata();
+
+export const setRequestHeaders = (headers: Record<string, string>) => {
+  requestHeaders = headers;
+}
 
 export default CogReader;


### PR DESCRIPTION
Our COG files aren't public and require authentication headers for access. 

This PR adds `setRequestHeaders` to enable setting custom headers, which will be passed to geotiff's `fromUrl` method.

Example usage:
```ts
import { cogProtocol, setRequestHeaders } from "@geomatico/maplibre-cog-protocol";

const token = '...';
setRequestHeaders({ authorization: `Bearer ${token}` });
maplibregl.addProtocol("cog", cogProtocol);
```