### PR TITLE
Add delete method to CustomRendererStore and support undefined in setColorFunction

### DIFF
--- a/src/render/custom/rendererStore.ts
+++ b/src/render/custom/rendererStore.ts
@@ -10,5 +10,8 @@ export default {
   },
   set: (url: string, renderer: Renderer) => {
     store[url] = renderer;
+  },
+  delete: (url: string) => {
+    delete store[url];
   }
 };

--- a/src/render/custom/setColorFunction.ts
+++ b/src/render/custom/setColorFunction.ts
@@ -2,8 +2,12 @@ import CustomRendererStore from './rendererStore';
 import {ColorFunction} from '../../types';
 import getColorFunctionRenderer from './getColorFunctionRenderer';
 
-const setColorFunction = (url: string, colorFunction: ColorFunction) => {
-  CustomRendererStore.set(url, getColorFunctionRenderer(colorFunction));
+const setColorFunction = (url: string, colorFunction: ColorFunction | undefined) => {
+  if (colorFunction === undefined) {
+    CustomRendererStore.delete(url);
+  } else {
+    CustomRendererStore.set(url, getColorFunctionRenderer(colorFunction));
+  }
 }
 
 export default setColorFunction;

--- a/test/render/custom/rendererStore.spec.ts
+++ b/test/render/custom/rendererStore.spec.ts
@@ -21,4 +21,12 @@ describe('rendererStore', () => {
       expect(renderer(new Int8Array(), dummyMetadata)).toEqual(sampleImage);
     }
   });
+
+  test('deletes a renderer from the store', () => {
+    RendererStore.set('to_delete.tif', () => sampleImage);
+    expect(RendererStore.get('to_delete.tif')).toBeInstanceOf(Function);
+    
+    RendererStore.delete('to_delete.tif');
+    expect(RendererStore.get('to_delete.tif')).toBeUndefined();
+  });
 });

--- a/test/render/custom/setColorFunction.spec.ts
+++ b/test/render/custom/setColorFunction.spec.ts
@@ -25,4 +25,16 @@ describe('setColorFunction', () => {
     expect(renderer).toEqual(fakeRenderer);
 
   });
+
+  test('removes a custom renderer from the store when colorFunction is undefined', () => {
+    // GIVEN
+    setColorFunction('sample.tif', () => {});
+    expect(CustomRendererStore.get('sample.tif')).toEqual(fakeRenderer);
+
+    // WHEN
+    setColorFunction('sample.tif', undefined);
+
+    // THEN
+    expect(CustomRendererStore.get('sample.tif')).toBeUndefined();
+  });
 });


### PR DESCRIPTION
This PR adds the ability to deregister custom color functions by calling setColorFunction(url, undefined).

Changes:

Added delete method to CustomRendererStore
Modified setColorFunction to check for undefined and call delete instead of setting a renderer

**Motivation:**
Currently, there is no way to remove a registered color function. This causes issues in dynamic applications where you need to switch between different rendering modes:

Mode switching: When switching from custom gradient mapping back to native RGB rendering, the old colorFunction persists and interferes with default rendering

**Use case:**
Our application renders COG files in two modes:

Interpolate mode: Single-band data with gradient mapping (requires custom colorFunction)
Raster mode: RGB/YCbCr data with native rendering (should NOT use colorFunction)
Without this change, we had to use workarounds like URL fragments to force separate tile caches, which is inefficient and error-prone.

**Backward compatibility:**
The change is fully backward compatible - existing code continues to work unchanged. The undefined parameter is opt-in for cleanup scenarios.


- Add delete method to CustomRendererStore to remove custom renderers
- Allow setColorFunction to accept undefined to remove custom color functions
- Add tests for both new features

