### PR TITLE
Fix terrain nodata guard for NaN GDAL_NODATA values

### DIFF
--- a/src/render/renderTerrain.ts
+++ b/src/render/renderTerrain.ts
@@ -13,7 +13,7 @@ const renderTerrain: ImageRenderer<Options> = (data: TypedArray, {offset, scale,
 
   for (let i = 0; i < pixels; i++) {
     const px = offset + data[i * numBands] * scale;
-    const h = px === noData ? 0 : px;
+    const h = Number.isFinite(px) && px !== noData ? px : 0;
     const v = (h - base) / interval;
     rgba[4 * i] = Math.floor(v / 256 / 256) % 256;
     rgba[4 * i + 1] = Math.floor(v / 256) % 256;

--- a/test/render/renderTerrain.spec.ts
+++ b/test/render/renderTerrain.spec.ts
@@ -36,6 +36,15 @@ describe('renderTerrain', () => {
     expect(px0(renderTerrain(data, {...baseOptions, noData: 99}))).toEqual([1, 134, 160, 255]);
   });
 
+  test('NaN noData pixel is encoded as elevation 0 (sea level), not -10000 m', () => {
+    // GDAL_NODATA = NaN: px === noData is never true, so the guard must also check finiteness.
+    expect(px0(renderTerrain(makeFloat(NaN), {...baseOptions, noData: NaN}))).toEqual([1, 134, 160, 255]);
+  });
+
+  test('Infinity pixel (out-of-extent fill value) is encoded as elevation 0 (sea level)', () => {
+    expect(px0(renderTerrain(makeFloat(Infinity), baseOptions))).toEqual([1, 134, 160, 255]);
+  });
+
   test('Everest (~8848 m) encodes correctly', () => {
     // v = (8848 + 10000) / 0.1 = 188480 → R=2, G=224, B=64
     expect(px0(renderTerrain(makeFloat(8848), baseOptions))).toEqual([2, 224, 64, 255]);


### PR DESCRIPTION
`px === noData` never matches when GDAL_NODATA is NaN, so nodata pixels reached the Terrain-RGB encoder as NaN/Infinity, clamped to (0,0,0), and decoded by MapLibre as -10000 m instead of sea level.                                                                                                                  

Fixes #50